### PR TITLE
refactor: Make formatting of command flags more generic

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,5 @@
+# Output test errors to stderr so users don't have to `cat` or open test failure log files when test
+# fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for
+# users.
+# Docs: https://bazel.build/docs/user-manual#test-output
+test --test_output=errors

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,3 +10,8 @@ bazel_toolchains_yocto_internal_deps()
 load("//yocto:repositories.bzl", "bazel_toolchains_yocto_dependencies")
 
 bazel_toolchains_yocto_dependencies()
+
+# For running unit tests
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()

--- a/yocto/tests/BUILD.bazel
+++ b/yocto/tests/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":common_utils_test.bzl", "common_utils_test_suite")
+
+common_utils_test_suite(name = "common_utils_test")

--- a/yocto/tests/common_utils_test.bzl
+++ b/yocto/tests/common_utils_test.bzl
@@ -1,0 +1,27 @@
+"""Unit tests for starlark helpers
+See https://bazel.build/rules/testing#testing-starlark-utilities
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//yocto/private:common_utils.bzl", "format_command_options")
+
+def _format_command_options_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, ["cmd", "arg1"], format_command_options("cmd arg1"))
+    asserts.equals(env, ["cmd", "arg1"], format_command_options("cmd    arg1"))
+    asserts.equals(env, ["cmd", "arg1"], format_command_options("\"cmd arg1\""))
+    asserts.equals(env, ["cmd", "arg1"], format_command_options("\"cmd\" \"arg1\""))
+    asserts.equals(env, ["cmd", "arg1"], format_command_options("\"cmd\" \"\" \"arg1\""))
+
+    asserts.equals(env, ["arg1", "arg2"], format_command_options("cmd arg1 arg2", True))
+    asserts.equals(env, ["arg1", "arg2"], format_command_options("   cmd arg1 arg2", True))
+    asserts.equals(env, ["arg1", "arg2"], format_command_options("\"cmd arg1\" arg2", True))
+
+    return unittest.end(env)
+
+# The unittest library requires that we export the test cases as named test rules,
+# but their names are arbitrary and don't appear anywhere.
+_t0_test = unittest.make(_format_command_options_test_impl)
+
+def common_utils_test_suite(name):
+    unittest.suite(name, _t0_test)


### PR DESCRIPTION
This change makes the formatting of the command line flags read from the
environment setup more generic to also process flags in the format of
environment variables.

As a bonus, this change also introduces the first unit test for starlark
code.
