### PR TITLE
Preparation for local SDK

### DIFF
--- a/yocto/tests/common_utils_test.bzl
+++ b/yocto/tests/common_utils_test.bzl
@@ -3,7 +3,11 @@ See https://bazel.build/rules/testing#testing-starlark-utilities
 """
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//yocto/private:common_utils.bzl", "format_command_options")
+load(
+    "//yocto/private:common_utils.bzl",
+    "format_command_options",
+    "relativize_sysroot_path",
+)
 
 def _format_command_options_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -19,9 +23,32 @@ def _format_command_options_test_impl(ctx):
 
     return unittest.end(env)
 
+def _relativize_sysroot_path_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        "base/sysroots/a",
+        relativize_sysroot_path(
+            "repository",
+            "/bazel/outputBase/external/repository/base",
+            "/path/to/base/sysroots/a",
+        ),
+    )
+    asserts.equals(
+        env,
+        "sysroots/a",
+        relativize_sysroot_path(
+            "repository",
+            "/bazel/outputBase/external/repository",
+            "/bazel/outputBase/external/repository/sysroots/a",
+        ),
+    )
+    return unittest.end(env)
+
 # The unittest library requires that we export the test cases as named test rules,
 # but their names are arbitrary and don't appear anywhere.
 _t0_test = unittest.make(_format_command_options_test_impl)
+_t1_test = unittest.make(_relativize_sysroot_path_test_impl)
 
 def common_utils_test_suite(name):
-    unittest.suite(name, _t0_test)
+    unittest.suite(name, _t0_test, _t1_test)


### PR DESCRIPTION
- [fix: consume sysroot variable via builtin_sysroot](https://github.com/pziggo/bazel-toolchains-yocto/commit/a11e55e3f828a3ec8153685b802b5fc26ad381a8)
- [refactor: Retrieve relative sysroot path more generic](https://github.com/pziggo/bazel-toolchains-yocto/commit/f2afe5a3e6697e32555e401241971c615c772146)