### PR TITLE
compat: Drop archive_flags from toolchain_config to support bazel5

### DIFF
--- a/yocto/private/common_utils.bzl
+++ b/yocto/private/common_utils.bzl
@@ -79,8 +79,6 @@ def env_to_config(repository_ctx, env, relative_root = "."):
 
     repo_root = str(repository_ctx.path(relative_root))
 
-    archive_flags = []
-
     compile_flags = format_command_options(env.get("CC"), True)
     cxx_builtin_include_directories = []
     dbg_compile_flags = []
@@ -143,7 +141,6 @@ def env_to_config(repository_ctx, env, relative_root = "."):
     link_flags = remove_elements_starting_with_keyword("--sysroot", link_flags)
 
     return struct(
-        archive_flags = archive_flags,
         builtin_sysroot = builtin_sysroot,
         compile_flags = compile_flags,
         cxx_builtin_include_directories = cxx_builtin_include_directories,

--- a/yocto/private/toolchain_template.bzl
+++ b/yocto/private/toolchain_template.bzl
@@ -108,7 +108,6 @@ cc_toolchain_config(
     opt_compile_flags = {opt_compile_flags},
     cxx_flags = {cxx_flags},
     link_flags = {link_flags},
-    archive_flags = {archive_flags},
     link_libs = {link_libs},
     opt_link_flags = {opt_link_flags},
     unfiltered_compile_flags = {unfiltered_compile_flags},
@@ -157,7 +156,6 @@ def BUILD_for_toolchain(name, config):
     """
     return _build_file_toolchain_template.format(
         name = name,
-        archive_flags = str(config.archive_flags),
         builtin_sysroot = str(config.builtin_sysroot),
         compile_flags = str(config.compile_flags),
         cxx_builtin_include_directories = str(config.cxx_builtin_include_directories),


### PR DESCRIPTION
In Bazel 5, `archive_flags` aren't supported yet. As there are no
specific flags from yocto, they can be removed in order to ensure
version compatibility.
