### PR TITLE
feat: Add the optional ability to disable toolchain registration after install

### DIFF
--- a/yocto/defs.bzl
+++ b/yocto/defs.bzl
@@ -9,6 +9,7 @@ def http_yocto_toolchain_archive(
         sdk_installer,
         build_file = None,
         build_file_content = "",
+        register_toolchain = True,
         **kwargs):
     """Download archived toolchain script
 
@@ -18,6 +19,7 @@ def http_yocto_toolchain_archive(
         build_file_content (label, optional): The content for the BUILD file for the SDK tree.
         environment_setup (str): Name of the environment setup file
         sdk_installer (str): Name of the self extracting toolchain script
+        register_toolchain (bool, optional): If the toolchain should be registered with bazel after installation.
         **kwargs (dict): Keyword arguments for the `http_archive`, see https://bazel.build/rules/lib/repo/http#http_archive.
     """
     http_archive(
@@ -31,6 +33,7 @@ def http_yocto_toolchain_archive(
         build_file = build_file,
         build_file_content = build_file_content,
         environment_setup = environment_setup,
+        register_toolchain = register_toolchain,
         # Labels will not be resolved to the end in repository rules ... files must be named as they are
         sdk_installer = "@{}_dl//:{}".format(name, sdk_installer),
     )
@@ -40,6 +43,7 @@ def http_yocto_toolchain_file(
         environment_setup,
         build_file = None,
         build_file_content = "",
+        register_toolchain = True,
         **kwargs):
     """Download self extracting toolchain script
 
@@ -48,6 +52,7 @@ def http_yocto_toolchain_file(
         build_file (label, optional): The file to use as the BUILD file for the SDK tree.
         build_file_content (label, optional): The content for the BUILD file for the SDK tree.
         environment_setup (str): Name of the environment setup file
+        register_toolchain (bool, optional): If the toolchain should be registered with bazel after installation.
         **kwargs (dict): Keyword arguments for the `http_file`, see https://bazel.build/rules/lib/repo/http#http_file.
     """
     http_file(
@@ -60,6 +65,7 @@ def http_yocto_toolchain_file(
         build_file = build_file,
         build_file_content = build_file_content,
         environment_setup = environment_setup,
+        register_toolchain = register_toolchain,
         # Labels will not be resolved to the end in repository rules ... files must be named as they are
         sdk_installer = "@{}_dl//file:downloaded".format(name),
     )

--- a/yocto/private/sdk_utils.bzl
+++ b/yocto/private/sdk_utils.bzl
@@ -2,14 +2,14 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
-    "//yocto/private:common_utils.bzl",
-    "env_pair",
-    "env_to_config",
-)
-load(
     "//yocto/private:build_templates.bzl",
     "BUILD_for_platform",
     "BUILD_for_sdk_tree",
+)
+load(
+    "//yocto/private:common_utils.bzl",
+    "env_pair",
+    "env_to_config",
 )
 load("//yocto/private:toolchain_template.bzl", "BUILD_for_toolchain")
 load(
@@ -38,11 +38,13 @@ def _setup_bazel_files(repository_ctx, config):
             executable = False,
         )
 
-    repository_ctx.file(
-        "bazel/BUILD.bazel",
-        content = BUILD_for_platform(config),
-        executable = False,
-    )
+    
+    if repository_ctx.attr.register_toolchain:
+        repository_ctx.file(
+            "bazel/BUILD.bazel",
+            content = BUILD_for_platform(config),
+            executable = False,
+        )
 
     repository_ctx.file(
         "bazel/toolchain/ld-linux-x86-64.so.2",
@@ -91,11 +93,12 @@ def _setup_bazel_files(repository_ctx, config):
         executable = True,
     )
 
-    repository_ctx.file(
-        "bazel/toolchain/BUILD.bazel",
-        content = BUILD_for_toolchain(repository_ctx.attr.name, config),
-        executable = False,
-    )
+    if repository_ctx.attr.register_toolchain:
+        repository_ctx.file(
+            "bazel/toolchain/BUILD.bazel",
+            content = BUILD_for_toolchain(repository_ctx.attr.name, config),
+            executable = False,
+        )
 
 def _read_env_from_environment_setup(repository_ctx):
     env = dict()
@@ -183,6 +186,15 @@ install_and_setup_sdk = repository_rule(
             mandatory = True,
             allow_single_file = True,
             doc = "",
+        ),
+        "register_toolchain": attr.bool(
+            mandatory = False,
+            default = True,
+            doc = 
+                "If the toolchain should be registered with bazel after installation, " +
+                "defaults to true. This is useful when you want fine grained control " +
+                "of the bazel toolchain definition, but still want to take advantage of " +
+                "the other featuers of link_and_setup_sdk.",
         ),
         "_post_script": attr.label(
             default = Label("//scripts:post_extract.sh"),


### PR DESCRIPTION
We have a use case where the default toolchain + platform registration doesn't work for us, so we would like to be able to inject our own. We can already do this with the custom BUILD file option, but we also need to be able to disable the generation of the toolchain + platform files that happen by default.

This PR introduces a new option `register_toolchain`, which defaults to `True`, and is plumbed down to the `install_and_setup_sdk` rule.

The default behavior is unchanged, unless users pass in their own value for this flag.