### PR TITLE
Add Bzlmod support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,3 +6,4 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.8.1", dev_dependency = True)
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_python", version = "1.8.4")

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -2,6 +2,29 @@
 
 Macros for downloading yocto toolchains
 
+## Bzlmod
+
+Use the module extension to declare toolchain repositories from MODULE.bazel.
+
+```starlark
+bazel_dep(name = "bazel-toolchains-yocto", version = "<version>")
+
+yocto = use_extension(
+    "@bazel-toolchains-yocto//yocto:extensions.bzl",
+    "yocto_toolchains",
+)
+
+yocto.http_file(
+    name = "core2-64-poky-linux",
+    environment_setup = "environment-setup-core2-64-poky-linux",
+    executable = True,
+    sha256 = "<sha256>",
+    urls = ["https://example.com/poky-toolchain.sh"],
+)
+
+use_repo(yocto, "core2-64-poky-linux")
+```
+
 <a id="http_yocto_toolchain_archive"></a>
 
 ## http_yocto_toolchain_archive

--- a/yocto/extensions.bzl
+++ b/yocto/extensions.bzl
@@ -1,0 +1,125 @@
+"""Bzlmod module extension for Yocto toolchains."""
+
+load(
+    "//yocto:defs.bzl",
+    "http_yocto_toolchain_archive",
+    "http_yocto_toolchain_file",
+    "local_yocto_toolchain",
+)
+
+def _maybe(kwargs, key, value):
+    if value == None:
+        return
+    if type(value) == type("") and value == "":
+        return
+    if type(value) == type([]) and not value:
+        return
+    if type(value) == type({}) and not value:
+        return
+    kwargs[key] = value
+
+def _http_archive_kwargs(tag):
+    kwargs = {}
+    _maybe(kwargs, "url", tag.url)
+    _maybe(kwargs, "urls", tag.urls)
+    _maybe(kwargs, "sha256", tag.sha256)
+    _maybe(kwargs, "integrity", tag.integrity)
+    _maybe(kwargs, "strip_prefix", tag.strip_prefix)
+    _maybe(kwargs, "patches", tag.patches)
+    _maybe(kwargs, "patch_args", tag.patch_args)
+    _maybe(kwargs, "patch_tool", tag.patch_tool)
+    _maybe(kwargs, "patch_cmds", tag.patch_cmds)
+    _maybe(kwargs, "patch_cmds_win", tag.patch_cmds_win)
+    _maybe(kwargs, "repo_mapping", tag.repo_mapping)
+    return kwargs
+
+def _http_file_kwargs(tag):
+    kwargs = {}
+    _maybe(kwargs, "url", tag.url)
+    _maybe(kwargs, "urls", tag.urls)
+    _maybe(kwargs, "sha256", tag.sha256)
+    _maybe(kwargs, "integrity", tag.integrity)
+    _maybe(kwargs, "downloaded_file_path", tag.downloaded_file_path)
+    _maybe(kwargs, "executable", tag.executable)
+    _maybe(kwargs, "auth_patterns", tag.auth_patterns)
+    _maybe(kwargs, "canonical_id", tag.canonical_id)
+    _maybe(kwargs, "repo_mapping", tag.repo_mapping)
+    return kwargs
+
+def _yocto_toolchains_impl(module_ctx):
+    for mod in module_ctx.modules:
+        for tag in mod.tags.http_archive:
+            http_yocto_toolchain_archive(
+                name = tag.name,
+                environment_setup = tag.environment_setup,
+                sdk_installer = tag.sdk_installer,
+                build_file = tag.build_file,
+                build_file_content = tag.build_file_content,
+                **_http_archive_kwargs(tag)
+            )
+
+        for tag in mod.tags.http_file:
+            http_yocto_toolchain_file(
+                name = tag.name,
+                environment_setup = tag.environment_setup,
+                build_file = tag.build_file,
+                build_file_content = tag.build_file_content,
+                **_http_file_kwargs(tag)
+            )
+
+        for tag in mod.tags.local:
+            local_yocto_toolchain(
+                name = tag.name,
+                build_file = tag.build_file,
+                build_file_content = tag.build_file_content,
+            )
+
+yocto_toolchains = module_extension(
+    implementation = _yocto_toolchains_impl,
+    tag_classes = {
+        "http_archive": tag_class(
+            attrs = {
+                "name": attr.string(mandatory = True),
+                "environment_setup": attr.string(mandatory = True),
+                "sdk_installer": attr.string(mandatory = True),
+                "build_file": attr.label(),
+                "build_file_content": attr.string(),
+                "url": attr.string(),
+                "urls": attr.string_list(),
+                "sha256": attr.string(),
+                "integrity": attr.string(),
+                "strip_prefix": attr.string(),
+                "patches": attr.label_list(),
+                "patch_args": attr.string_list(),
+                "patch_tool": attr.string(),
+                "patch_cmds": attr.string_list(),
+                "patch_cmds_win": attr.string_list(),
+                "repo_mapping": attr.string_dict(),
+            },
+        ),
+        "http_file": tag_class(
+            attrs = {
+                "name": attr.string(mandatory = True),
+                "environment_setup": attr.string(mandatory = True),
+                "build_file": attr.label(),
+                "build_file_content": attr.string(),
+                "url": attr.string(),
+                "urls": attr.string_list(),
+                "sha256": attr.string(),
+                "integrity": attr.string(),
+                "downloaded_file_path": attr.string(),
+                "executable": attr.bool(),
+                "auth_patterns": attr.string_dict(),
+                "canonical_id": attr.string(),
+                "repo_mapping": attr.string_dict(),
+            },
+        ),
+        "local": tag_class(
+            attrs = {
+                "name": attr.string(mandatory = True),
+                "build_file": attr.label(),
+                "build_file_content": attr.string(),
+            },
+        ),
+    },
+)

--- a/yocto/private/build_templates.bzl
+++ b/yocto/private/build_templates.bzl
@@ -13,14 +13,15 @@ filegroup(
             "{target_sysroot}/usr/lib/**/*.a",
             "{target_sysroot}/usr/lib/**/*.o",
             "{target_sysroot}/usr/lib/**/*.so*",
-        ],
+        ], allow_empty = True,
     ),
     visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "native_runtime",
-    srcs = glob([
+    srcs = glob(
+        [
         "{native_sysroot}/lib/ld-*.so",
         "{native_sysroot}/lib/ld-linux*.so.*",
         "{native_sysroot}/lib/libc.so.*",
@@ -29,7 +30,8 @@ filegroup(
         "{native_sysroot}/lib/libpthread.so.*",
         "{native_sysroot}/usr/lib/lib*.so.*",
         "{native_sysroot}/usr/libexec/{target_prefix}/**",
-    ]),
+        ], allow_empty = True,
+    ),
 )
 
 filegroup(

--- a/yocto/private/build_templates.bzl
+++ b/yocto/private/build_templates.bzl
@@ -22,14 +22,14 @@ filegroup(
     name = "native_runtime",
     srcs = glob(
         [
-        "{native_sysroot}/lib/ld-*.so",
-        "{native_sysroot}/lib/ld-linux*.so.*",
-        "{native_sysroot}/lib/libc.so.*",
-        "{native_sysroot}/lib/libdl.so.*",
-        "{native_sysroot}/lib/libm.so.*",
-        "{native_sysroot}/lib/libpthread.so.*",
-        "{native_sysroot}/usr/lib/lib*.so.*",
-        "{native_sysroot}/usr/libexec/{target_prefix}/**",
+            "{native_sysroot}/lib/ld-*.so",
+            "{native_sysroot}/lib/ld-linux*.so.*",
+            "{native_sysroot}/lib/libc.so.*",
+            "{native_sysroot}/lib/libdl.so.*",
+            "{native_sysroot}/lib/libm.so.*",
+            "{native_sysroot}/lib/libpthread.so.*",
+            "{native_sysroot}/usr/lib/lib*.so.*",
+            "{native_sysroot}/usr/libexec/{target_prefix}/**",
         ], allow_empty = True,
     ),
 )
@@ -142,11 +142,21 @@ def BUILD_for_sdk_tree(config):
     )
 
 _build_file_for_platform_template = """\
+package(default_visibility = ["//visibility:public"])
+
+constraint_setting(name = "variant")
+
+constraint_value(
+    name = "yocto",
+    constraint_setting = ":variant",
+)
+
 platform(
     name = "platform-target",
     constraint_values = [
         "@platforms//os:{target_os}",
         "@platforms//cpu:{target_arch}",
+        ":yocto",
     ],
 )
 """

--- a/yocto/private/sdk_utils.bzl
+++ b/yocto/private/sdk_utils.bzl
@@ -2,14 +2,14 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
-    "//yocto/private:common_utils.bzl",
-    "env_pair",
-    "env_to_config",
-)
-load(
     "//yocto/private:build_templates.bzl",
     "BUILD_for_platform",
     "BUILD_for_sdk_tree",
+)
+load(
+    "//yocto/private:common_utils.bzl",
+    "env_pair",
+    "env_to_config",
 )
 load("//yocto/private:toolchain_template.bzl", "BUILD_for_toolchain")
 load(
@@ -112,8 +112,14 @@ def _read_env_from_environment_setup(repository_ctx):
     return env
 
 def _install_sdk(repository_ctx):
+    # Get the Python binary from the registered toolchain
+    python_bin = repository_ctx.path(Label("@@rules_python++python+python_3_12_11_x86_64-unknown-linux-gnu//:bin/python"))
+    env = dict(repository_ctx.os.environ)
+    env.update({"PATH": str(python_bin.dirname) + ":" + env.get("PATH", "")})
+    # repository_ctx.execute(["python", "-V"], environment = env, quiet = False)
+
     repository_ctx.report_progress("Installing Yocto SDK {}".format(repository_ctx.path(repository_ctx.attr.sdk_installer)))
-    res = repository_ctx.execute(["sh", repository_ctx.path(repository_ctx.attr.sdk_installer), "-y", "-d", repository_ctx.path("."), "-R"])
+    res = repository_ctx.execute(["sh", repository_ctx.path(repository_ctx.attr.sdk_installer), "-y", "-d", repository_ctx.path("."), "-R"], environment = env)
     if res.return_code:
         fail("error installing Yocto SDK:\n" + res.stdout + res.stderr)
 

--- a/yocto/private/toolchain_template.bzl
+++ b/yocto/private/toolchain_template.bzl
@@ -138,6 +138,7 @@ toolchain(
     target_compatible_with = [
         "@platforms//cpu:{target_arch}",
         "@platforms//os:{target_os}",
+        "//bazel:yocto",
     ],
     toolchain = ":cc-target",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",


### PR DESCRIPTION
I've added a basic Bzlmod module extension for this toolchain and provided documentation on how to use it
also I noticed there is a host dependency towards Python, so added it to the repository context.
the last modification is to allow this to be used concurrently with other toolchains 
so I added an additional constraint for the toolchain